### PR TITLE
To my Master branch - Fix Readme code

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ import (
     "github.com/rapid7/go-get-proxied/proxy"
 )
 func main() {
-    p := proxy.NewProvider("").Get("https", "https://rapid7.com")
+    p := proxy.NewProvider("").GetProxy("https", "https://rapid7.com")
     if p != nil {
         fmt.Printf("Found proxy: %s\n", p)
     }


### PR DESCRIPTION
## Description

The example code in README.MD in incorrect (and probably outdated). This PR fixes this.

Change can be viewed here: https://github.com/rapid7/go-get-proxied/commit/7c7cc2c9fc4263ca8314baea9110653c06e30750

> p := proxy.NewProvider("").Get("https", "https://rapid7.com")

is changed to,

> p := proxy.NewProvider("").Get**Proxy**("https", "https://rapid7.com")

I decided to create this PR, as I tried to use this code and found a fault in README.MD .

## Testing

Below is the list of confirmations for the need for example code to be fixed.

**Firstly:** I ran the code myself

* I ran the example code, and here is the listing.
```

C:\Projects\PR-tests>cat test_for_PR1.go
package main
import (
    "fmt"
    "github.com/rapid7/go-get-proxied/proxy"
)
func main() {
    p := proxy.NewProvider("").Get("https", "https://rapid7.com")
    if p != nil {
        fmt.Printf("Found proxy: %s\n", p)
    }
}

C:\Projects\PR-tests>go run test_for_PR1.go
# command-line-arguments
.\test_for_PR1.go:7:32: proxy.NewProvider("").Get undefined (type proxy.Provider
 has no field or method Get)

C:\Projects\PR-tests>
```

* However, corrected code does work,

```

C:\Projects\PR-tests>cat test_for_PR2.go
package main
import (
    "fmt"
    "github.com/rapid7/go-get-proxied/proxy"
)
func main() {
    p := proxy.NewProvider("").GetProxy("https", "https://rapid7.com")
    if p != nil {
        fmt.Printf("Found proxy: %s\n", p)
    }
}

C:\Projects\PR-tests>go run test_for_PR2.go
Found proxy: WinHTTP:NamedProxy|://1.1.1.1:80

C:\Projects\PR-tests>
```

**Secondly:** I checked upstream code, and, there is `type Provider interface`, which does not define `Get`, but does define `GetProxy`, https://github.com/rapid7/go-get-proxied/blob/798791728c560ff39b276dce7f8e25e56be68d85/proxy/provider.go#L40

**Thirdly:** Third-party code also uses `GetProxy()`, for example, here: https://github.com/keyring-so/keyring-desktop/blob/9c6ca18257fee150f922d7559a85e7270373bcdc/app.go#L80

In light of these factors, I'm making this Push Request.
